### PR TITLE
Add automatic light/dark mode theme switching

### DIFF
--- a/Library/LaunchAgents/local.dark-notify-zellij.plist.tmpl
+++ b/Library/LaunchAgents/local.dark-notify-zellij.plist.tmpl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>local.dark-notify-zellij</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/opt/homebrew/bin/dark-notify</string>
+      <string>-c</string>
+      <string>{{ .chezmoi.homeDir }}/.local/bin/toggle-zellij-theme.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+  </dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains configuration files for my development workflow, featur
 - **Ghostty** terminal with automatic Zellij multiplexing
 - **Git** with GPG commit signing via 1Password
 
-All configurations use the **Gruvbox Dark Hard** color scheme for visual consistency.
+All configurations use the **Gruvbox** color scheme with **automatic light/dark mode switching** based on system appearance.
 
 ## Prerequisites
 
@@ -28,6 +28,9 @@ These tools are configured but need to be installed separately:
 ```bash
 brew install fish neovim git bat btop atuin zoxide ghostty
 brew install --cask 1password
+
+# For automatic dark mode switching (macOS)
+brew install cormacrelf/tap/dark-notify
 ```
 
 ## Quick Start
@@ -67,7 +70,7 @@ chezmoi update
 
 - **nvim** ([neovim.io](https://neovim.io))
   - **LazyVim** distribution with sensible defaults
-  - **Gruvbox Hard** colorscheme
+  - **Gruvbox Hard** colorscheme with automatic light/dark switching
   - Custom keymap: `kj` in insert mode → `<Esc>`
   - Plugins configured in `lua/plugins/`
 
@@ -76,11 +79,11 @@ chezmoi update
 - **ghostty** ([ghostty.org](https://ghostty.org))
   - **Berkeley Mono Variable** font
   - Auto-launches Zellij session "main"
-  - Gruvbox Dark Hard theme
+  - Automatic light/dark theme switching
 
 - **zellij** ([zellij.dev](https://zellij.dev))
   - Compact layout
-  - Gruvbox Dark theme
+  - Automatic light/dark theme switching
 
 ### Version Control
 
@@ -93,6 +96,41 @@ chezmoi update
 
 - **bat**: Syntax-highlighted `cat` replacement
 - **btop**: Modern system monitor
+
+## Automatic Dark Mode
+
+This setup includes automatic theme switching across **Ghostty**, **Neovim**, and **Zellij** based on macOS system appearance.
+
+### How It Works
+
+- **Ghostty**: Native support for light/dark theme switching
+- **Neovim**: Uses the `dark-notify` plugin to watch system appearance
+- **Zellij**: Automated via `dark-notify` and a background service
+
+### Setup (macOS only)
+
+After running `chezmoi apply`, load the launch agent:
+
+```bash
+launchctl load ~/Library/LaunchAgents/local.dark-notify-zellij.plist
+```
+
+To verify it's running:
+
+```bash
+launchctl list | grep dark-notify
+```
+
+### Manual Theme Switching
+
+If you prefer manual control or need to test:
+
+```bash
+~/.local/bin/toggle-zellij-theme.sh light
+~/.local/bin/toggle-zellij-theme.sh dark
+```
+
+Ghostty and Neovim will automatically follow system appearance without manual intervention.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -107,20 +107,6 @@ This setup includes automatic theme switching across **Ghostty**, **Neovim**, an
 - **Neovim**: Uses the `dark-notify` plugin to watch system appearance
 - **Zellij**: Automated via `dark-notify` and a background service
 
-### Setup (macOS only)
-
-After running `chezmoi apply`, load the launch agent:
-
-```bash
-launchctl load ~/Library/LaunchAgents/local.dark-notify-zellij.plist
-```
-
-To verify it's running:
-
-```bash
-launchctl list | grep dark-notify
-```
-
 ### Manual Theme Switching
 
 If you prefer manual control or need to test:

--- a/dot_Brewfile
+++ b/dot_Brewfile
@@ -1,0 +1,36 @@
+# Taps
+tap "cormacrelf/tap"
+
+# CLI tools
+brew "atuin"
+brew "bat"
+brew "btop"
+brew "bun"
+brew "chezmoi"
+brew "codex"
+brew "dbmate"
+brew "difftastic"
+brew "fish"
+brew "gh"
+brew "git"
+brew "jj"
+brew "lazydocker"
+brew "lazygit"
+brew "neovim"
+brew "terraform"
+brew "tree"
+brew "yt-dlp"
+brew "zellij"
+brew "zoxide"
+
+# Dark mode switching
+brew "cormacrelf/tap/dark-notify"
+
+# Casks
+cask "1password"
+cask "calibre"
+cask "claude-code"
+cask "cursor"
+cask "docker"
+cask "ghostty"
+cask "raycast"

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -6,7 +6,7 @@ font-size = 14
 
 # Theme configuration
 # Automatically switches between light and dark themes based on system appearance
-theme = light:GruvboxLightHard,dark:GruvboxDarkHard
+theme = light:Gruvbox Light Hard,dark:Gruvbox Dark Hard
 
 # Window configuration
 window-padding-x = 10 

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -5,7 +5,8 @@ font-variation = wght=500
 font-size = 14
 
 # Theme configuration
-theme = Gruvbox Dark Hard
+# Automatically switches between light and dark themes based on system appearance
+theme = light:GruvboxLightHard,dark:GruvboxDarkHard
 
 # Window configuration
 window-padding-x = 10 

--- a/dot_config/nvim/lua/plugins/dark-mode.lua
+++ b/dot_config/nvim/lua/plugins/dark-mode.lua
@@ -1,0 +1,9 @@
+-- Automatic dark mode switching based on system appearance
+return {
+  {
+    "cormacrelf/dark-notify",
+    config = function()
+      require("dark_notify").run()
+    end,
+  },
+}

--- a/dot_local/bin/executable_toggle-zellij-theme.sh.tmpl
+++ b/dot_local/bin/executable_toggle-zellij-theme.sh.tmpl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+ZELLIJ_CONFIG_PATH="{{ .chezmoi.homeDir }}/.config/zellij/config.kdl"
+ZELLIJ_THEME_LIGHT="gruvbox-light"
+ZELLIJ_THEME_DARK="gruvbox-dark"
+
+switch_zellij_theme() {
+  local theme=$1
+  if [[ $theme == "light" ]]; then
+    sed -i '' -E "s/^theme .*/theme \"$ZELLIJ_THEME_LIGHT\"/" "$ZELLIJ_CONFIG_PATH"
+  elif [[ $theme == "dark" ]]; then
+    sed -i '' -E "s/^theme .*/theme \"$ZELLIJ_THEME_DARK\"/" "$ZELLIJ_CONFIG_PATH"
+  else
+    echo "Error: Invalid theme '$theme'. Expected 'light' or 'dark'." >&2
+    exit 1
+  fi
+}
+
+if [[ $# -eq 0 ]]; then
+  echo "Error: Missing theme argument." >&2
+  exit 1
+fi
+
+switch_zellij_theme "$1"

--- a/run_onchange_after_load-launchd.sh.tmpl
+++ b/run_onchange_after_load-launchd.sh.tmpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+# {{ include "Library/LaunchAgents/local.dark-notify-zellij.plist.tmpl" | sha256sum }}
+
+{{ if eq .chezmoi.os "darwin" -}}
+PLIST="$HOME/Library/LaunchAgents/local.dark-notify-zellij.plist"
+
+if [ -f "$PLIST" ]; then
+    launchctl unload "$PLIST" 2>/dev/null || true
+    launchctl load "$PLIST"
+    echo "Loaded dark-notify-zellij launch agent"
+fi
+{{- end }}


### PR DESCRIPTION
Implements automatic theme synchronization across Ghostty, Neovim, and
Zellij based on macOS system appearance settings.

Changes:
- Ghostty: Native light/dark theme support with GruvboxLightHard/GruvboxDarkHard
- Neovim: Add dark-notify plugin for automatic theme switching
- Zellij: Add toggle script and launchd service for automated theme changes
- README: Document automatic dark mode feature and setup instructions

Inspired by https://arslan.io/2025/06/06/automatic-dark-mode-for-terminal-apps-revisited/